### PR TITLE
Grads 2.0.2

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,10 @@
+### Este projeto consiste no build da versão 2.0.2 do Grid Analysis and Display System (GrADS).
+
+O GrADS é uma ferramenta de visualização, manipulação e fácil acesso de dados meteorológicos.
+
+Ainda em construção.
+
+TODOS:
+ - build e deployment automático com ansible;
+ - melhorar esta documentação
+

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.3
+
+FROM centos:7
+
+COPY ./packages.repo /etc/yum.repos.d/CentOS-Base.repo
+
+RUN yum clean all
+
+RUN yum update -y
+
+WORKDIR /grads_files
+
+RUN mkdir -p /grads_files/data2
+
+RUN mkdir -p /usr/local/lib/grads
+
+RUN yum install wget vim tar -y && \ 
+    wget http://cola.gmu.edu/grads/2.2/grads-2.2.0-bin-centos7.3-x86_64.tar.gz && \
+    wget http://cola.gmu.edu/grads/data2.tar.gz && \
+    wget http://cola.gmu.edu/grads/data2.tar.gz -O /grads_files/data2/data2.tar.gz && \
+    tar -xzf grads-2.2.0-bin-centos7.3-x86_64.tar.gz && \
+    cp -r grads-2.2.0/bin/ /usr/local/ && \
+    cp -r grads-2.2.0/lib/ /usr/local/lib/grads/
+    
+WORKDIR /grads_files/data2
+
+RUN tar -xzf data2.tar.gz && \
+    cp -r * /usr/local/lib/grads/
+
+ENV GADDIR="/usr/local/lib/grads/"
+
+COPY ./udpt /usr/local/lib/grads/lib/udpt
+
+ENV GAUDPT="/usr/local/lib/grads/lib/udpt"
+    
+ENTRYPOINT ["/bin/bash"]
+     	

--- a/docker/packages.repo
+++ b/docker/packages.repo
@@ -1,0 +1,31 @@
+[base]                                                                                                                                                                                        
+name=CentOS-$releasever - Base                                                                                                                                                                
+mirrorlist=http://vault.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra                                                                                                   
+baseurl=http://vault.centos.org/centos/$releasever/os/$basearch/                                                                                                                              
+gpgcheck=1                                                                                                                                                                                    
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7                                                                                                                                           
+                                                                                                                                                                                              
+#released updates                                                                                                                                                                             
+[updates]                                                                                                                                                                                     
+name=CentOS-$releasever - Updates                                                                                                                                                             
+mirrorlist=http://vault.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra                                                                                              
+baseurl=http://vault.centos.org/centos/$releasever/updates/$basearch/            
+gpgcheck=1                                                                      
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7                              
+                                                                                
+#additional packages that may be useful                                         
+[extras]                                                                        
+name=CentOS-$releasever - Extras                                                
+mirrorlist=http://vault.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/             
+gpgcheck=1                                                                      
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7                              
+                                                                                
+#additional packages that extend functionality of existing packages              
+[centosplus]                                                                    
+name=CentOS-$releasever - Plus                                                  
+mirrorlist=http://vault.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+baseurl=http://vault.centos.org/centos/$releasever/centosplus/$basearch/         
+gpgcheck=1                                                                      
+enabled=0                                                                       
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/docker/udpt
+++ b/docker/udpt
@@ -1,0 +1,9 @@
+# Type     Name     Full path to shared object file
+# ----     ----     -------------------------------
+gxdisplay  Cairo    /usr/local/lib/grads/lib/libgxdCairo.so
+gxdisplay  X11      /usr/local/lib/grads/lib/libgxdX11.so
+gxdisplay  linux  /usr/local/lib/grads/lib/libgxdummy.so
+#*
+gxprint    Cairo    /usr/local/lib/grads/lib/libgxpCairo.so
+gxprint    GD       /usr/local/lib/grads/lib/libgxpGD.so
+gxprint    grads2  /usr/local/lib/grads/lib/libgxdummy.so


### PR DESCRIPTION
Este commit envia os arquivos necessários para fazer build e rodar o GraDS na versão 2.0.2 em container na engine docker. readthedocs: http://cola.gmu.edu/grads/downloads.php